### PR TITLE
Add script to fetch Fireflies user info

### DIFF
--- a/connect_fireflies.py
+++ b/connect_fireflies.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Simple helper to fetch user info from Fireflies.ai using the API key."""
+import json
+import os
+import sys
+import urllib.request
+
+API_URL = "https://api.fireflies.ai/v1/user"
+
+def main() -> None:
+    api_key = os.environ.get("FIREFLIES_API_KEY")
+    if not api_key:
+        raise SystemExit("FIREFLIES_API_KEY environment variable is not set")
+
+    request = urllib.request.Request(
+        API_URL,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+
+    with urllib.request.urlopen(request) as response:
+        data = response.read()
+
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        sys.stdout.buffer.write(data)
+    else:
+        print(json.dumps(payload, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/set_fireflies_api_key.sh
+++ b/set_fireflies_api_key.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+export FIREFLIES_API_KEY="fdf0b471-0d11-4243-b98a-b6940eb64f6a"


### PR DESCRIPTION
## Summary
- add Python helper to query Fireflies user endpoint using the API key

## Testing
- `bash -n set_fireflies_api_key.sh`
- `python -m py_compile connect_fireflies.py`
- `source set_fireflies_api_key.sh && python connect_fireflies.py` *(fails: URLError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68966f70ff7483309786ebb588dfe5c3